### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -104,7 +104,7 @@ class DashboardRequest(BaseHTTPServer.BaseHTTPRequestHandler):
     {'/'             : self.HandleStatus,
      '/check_url'    : self.HandleCheckUrl,
      '/quitquitquit' : self.Quit}.get(self.path,
-                    lambda: self.send_error(404, '%s not found' % self.path))()
+                    lambda: self.send_error(404, '{0!s} not found'.format(self.path)))()
 
   def HandleStatus(self):
     write = self.wfile.write
@@ -120,13 +120,13 @@ class DashboardRequest(BaseHTTPServer.BaseHTTPRequestHandler):
     if sync_time is None:
       write('Client waiting for initial sync.<br/>')
     else:
-      write('Client completed initial sync at %s after %d downloads.<br/>' % (
+      write('Client completed initial sync at {0!s} after {1:d} downloads.<br/>'.format(
           sync_time, sync_updates))
-    write('Client received last update at %s.<br/>' % (stats_time,))
+    write('Client received last update at {0!s}.<br/>'.format(stats_time))
 
     for s in lists_stats:
-      write('<table border=1><tr><th align=left>%s</th></tr></table>' % (
-          s.chunk_range_str,))
+      write('<table border=1><tr><th align=left>{0!s}</th></tr></table>'.format(
+          s.chunk_range_str))
       write('<table border=1><tr><th>Expressions</th>' +
         '<th>Add Chunks</th><th>Sub Chunks</th>' +
         '<th>Expressions / Chunk</th></tr>')
@@ -148,17 +148,17 @@ class DashboardRequest(BaseHTTPServer.BaseHTTPRequestHandler):
     write('<html><head><title>Check URL</title></head><body>')
     url_param = self.query_params.get(DashboardRequest.PARAM_URL, [])
     if len(url_param) != 1:
-      write('bad url query param: "%s"</body></html>' % (url_param,))
+      write('bad url query param: "{0!s}"</body></html>'.format(url_param))
       return
     url = url_param[0]
     matches = self.server.sbc.CheckUrl(url, debug_info=True)
     if len(matches) == 0:
-      write('No matches for "%s"</body></html>' % (url,))
+      write('No matches for "{0!s}"</body></html>'.format(url))
       return
 
     write('<ul>')
     for listname, match, addchunknum in matches:
-      write('<li>%s, addchunk number %d: %s</li>' % (
+      write('<li>{0!s}, addchunk number {1:d}: {2!s}</li>'.format(
           listname, addchunknum, match))
     write('</ul></body></html>')
 

--- a/python/client.py
+++ b/python/client.py
@@ -293,7 +293,7 @@ class Client(object):
       self._exit_cond.acquire()
       try:
         if not self._exit_updater:
-          logging.info('Waiting %d seconds' % delay)
+          logging.info('Waiting {0:d} seconds'.format(delay))
           self._exit_cond.wait(delay)
         if self._exit_updater:
           logging.info('Exiting')
@@ -380,12 +380,12 @@ class UrlChecker(object):
     for url in self._urls:
       matches = cl.CheckUrl(url)
       logging.info('CheckUrl %s: %s', url, matches)
-      print '%s:' % (url,)
+      print '{0!s}:'.format(url)
       if len(matches) == 0:
         print '\t(no matches)'
       else:
         for listname, matching in matches:
-          print '\t%s: %s' % (listname, matching)
+          print '\t{0!s}: {1!s}'.format(listname, matching)
     self._event.set()
 
   def WaitForFinish(self):

--- a/python/expression.py
+++ b/python/expression.py
@@ -62,7 +62,7 @@ class ExpressionGenerator(object):
   DEFAULT_PORTS = {'http': '80', 'https': '443', 'ftp': '21'}
 
   def __init__(self, url):
-    parse_exception = UrlParseError('failed to parse URL "%s"' % (url,))
+    parse_exception = UrlParseError('failed to parse URL "{0!s}"'.format(url))
     canonical_url = ExpressionGenerator.CanonicalizeUrl(url)
     if not canonical_url:
       raise parse_exception
@@ -277,7 +277,7 @@ class ExpressionGenerator(object):
 
     while len(ip) < 4:
       ip.append(0)
-    return '%u.%u.%u.%u' % tuple(ip)
+    return '{0:d}.{1:d}.{2:d}.{3:d}'.format(*tuple(ip))
 
   def Expressions(self):
     """

--- a/python/expression_test.py
+++ b/python/expression_test.py
@@ -57,7 +57,7 @@ class CanonicalizationTest(unittest.TestCase):
     for testip, expected in ips:
       actual = expression.ExpressionGenerator.CanonicalizeIp(testip)
       self.assertEqual(actual, expected,
-                       'test input: %s, actual: %s, expected: %s' % (testip,
+                       'test input: {0!s}, actual: {1!s}, expected: {2!s}'.format(testip,
                                                                      actual,
                                                                      expected))
 
@@ -145,7 +145,7 @@ class CanonicalizationTest(unittest.TestCase):
       actual = expression.ExpressionGenerator.CanonicalizeUrl(testin)
       self.assertEqual(
           actual, expected,
-          'test input: %s, actual: %s, expected: %s' % (
+          'test input: {0!s}, actual: {1!s}, expected: {2!s}'.format(
           testin, actual, expected))
 
 
@@ -154,11 +154,11 @@ class ExprGenTest(unittest.TestCase):
     gen = expression.ExpressionGenerator(url)
     exprs = list(gen.Expressions())
     self.assertEqual(len(exprs), len(expected),
-                    'Length mismatch.\nExpected: %s\nActual:  %s' % (
+                    'Length mismatch.\nExpected: {0!s}\nActual:  {1!s}'.format(
         expected, exprs))
     for i in xrange(len(exprs)):
       self.assertEqual(exprs[i].Value(), expected[i],
-                       'List mismatch.\nExpected: %s\nAactual:  %s' % (expected,
+                       'List mismatch.\nExpected: {0!s}\nAactual:  {1!s}'.format(expected,
                                                                        exprs))
 
   def testExpressionGenerator(self):

--- a/python/sblist.py
+++ b/python/sblist.py
@@ -146,7 +146,7 @@ class List(object):
     """
     Return True iff there is a prefix to remove.
     """
-    logmsg = '%s:%d:%s' % (self.Name(), addchunknum, util.Bin2Hex(prefix))
+    logmsg = '{0!s}:{1:d}:{2!s}'.format(self.Name(), addchunknum, util.Bin2Hex(prefix))
     logging.debug('attempted sub: %s', logmsg)
 
     # Lets see if we already have the corresponding add entry.
@@ -184,8 +184,8 @@ class List(object):
     data.  If data currently exists for the chunk it is removed.
     """
     if self.DeleteAddChunk(addchunknum):
-      logging.debug("Removing data that was associated with add chunk %d" %
-                    addchunknum)
+      logging.debug("Removing data that was associated with add chunk {0:d}".format(
+                    addchunknum))
     self._chunknum_map[addchunknum] = {}
 
   def AddEmptySubChunk(self, subchunknum):
@@ -248,18 +248,18 @@ class List(object):
     addnums.sort()
     subnums = self._subchunks.keys()
     subnums.sort()
-    dlreq = '%s;' % (self.Name(),)
+    dlreq = '{0!s};'.format(self.Name())
     if addnums:
-      dlreq = '%sa:%s' % (dlreq, self._GetRangeStr(addnums))
+      dlreq = '{0!s}a:{1!s}'.format(dlreq, self._GetRangeStr(addnums))
     if subnums:
       if addnums:
-        dlreq = '%s:' % (dlreq,)
-      dlreq = '%ss:%s' % (dlreq, self._GetRangeStr(subnums))
+        dlreq = '{0!s}:'.format(dlreq)
+      dlreq = '{0!s}s:{1!s}'.format(dlreq, self._GetRangeStr(subnums))
     if should_mac:
       if addnums or subnums:
-        dlreq = '%s:mac' % (dlreq,)
+        dlreq = '{0!s}:mac'.format(dlreq)
       else:
-        dlreq = '%smac' % (dlreq,)
+        dlreq = '{0!s}mac'.format(dlreq)
     return dlreq
 
   def _GetRangeStr(self, nums):
@@ -309,7 +309,7 @@ class AddEntry(object):
     f = self._fulllength
     if f is not None:
       f = util.Bin2Hex(f)
-    return 'AddEntry(%s, %s, %d)' % (p, f, self._addchunknum)
+    return 'AddEntry({0!s}, {1!s}, {2:d})'.format(p, f, self._addchunknum)
 
   def __eq__(self, other):
     return str(self) == str(other)
@@ -356,7 +356,7 @@ class SubEntry(object):
     self._addnum = addchunknum
 
   def __str__(self):
-    return 'SubEntry(%s, sub:%d, add:%d)' % (util.Bin2Hex(self.Prefix()),
+    return 'SubEntry({0!s}, sub:{1:d}, add:{2:d})'.format(util.Bin2Hex(self.Prefix()),
                                              self.SubNum(), self.AddNum())
 
   def __cmp__(self, other):

--- a/python/sblist_test.py
+++ b/python/sblist_test.py
@@ -28,8 +28,7 @@ class ListTest(unittest.TestCase):
   def assertSameElements(self, a, b):
     a = sorted(list(a))
     b = sorted(list(b))
-    self.assertEqual(a, b, 'Expected: [%s], Found: [%s]' %
-                     (', '.join(map(str, a)), ', '.join(map(str, b))))
+    self.assertEqual(a, b, 'Expected: [{0!s}], Found: [{1!s}]'.format(', '.join(map(str, a)), ', '.join(map(str, b))))
 
   def setUp(self):
     self._list = sblist.List('goog-malware-shavar')

--- a/python/server_test.py
+++ b/python/server_test.py
@@ -36,7 +36,7 @@ class HTTPError(Exception):
     self.code = code
 
   def __str__(self):
-    return 'HTTPError code:%d' % self.code
+    return 'HTTPError code:{0:d}'.format(self.code)
 
 
 class FakeServer(object):
@@ -85,7 +85,7 @@ class FakeServer(object):
           raise response
         else:
           return StringIO.StringIO(response)
-    raise Exception('No such data: %s' % url)
+    raise Exception('No such data: {0!s}'.format(url))
 
 
 class ServerTest(unittest.TestCase):
@@ -108,8 +108,8 @@ class ServerTest(unittest.TestCase):
 
   def testGetLists(self):
     response = 'lista\nlistb\nlistc'
-    response = '%s\n%s' % (self._Mac(response), response)
-    self._fake_sb_server.SetResponse(url_prefix='%s/list?' % self._base_url,
+    response = '{0!s}\n{1!s}'.format(self._Mac(response), response)
+    self._fake_sb_server.SetResponse(url_prefix='{0!s}/list?'.format(self._base_url),
                                      params=[('wrkey', 'BOGUS_WRAPPED_KEY'),
                                              ('apikey', 'BOGUS_API_KEY')],
                                      request=None,
@@ -151,7 +151,7 @@ class ServerTest(unittest.TestCase):
         'a:1:6:1546\n' +
         # Test an edge case where there are more than 255 entries for
         # the same host key
-        '1234\xFF%s' % ''.join(map(str, range(100000, 100255))) +
+        '1234\xFF{0!s}'.format(''.join(map(str, range(100000, 100255)))) +
         '1234\x01100255')
 
     self._fake_sb_server.SetResponse(
@@ -173,21 +173,21 @@ class ServerTest(unittest.TestCase):
 
     response = '\n'.join(['n:1800',
                           'i:lista',
-                          'u:rd.com/lista-s,%s' %
-                          self._Mac(lista_s_redirect_response),
-                          'u:rd.com/lista-a,%s' %
-                          self._Mac(lista_a_redirect_response),
+                          'u:rd.com/lista-s,{0!s}'.format(
+                          self._Mac(lista_s_redirect_response)),
+                          'u:rd.com/lista-a,{0!s}'.format(
+                          self._Mac(lista_a_redirect_response)),
                           'ad:1-2,4-5,7',
                           'i:listb',
-                          'u:rd.com/listb-a,%s' %
-                          self._Mac(listb_a_redirect_response),
+                          'u:rd.com/listb-a,{0!s}'.format(
+                          self._Mac(listb_a_redirect_response)),
                           'sd:2-6'])
     self._fake_sb_server.SetResponse(
-        url_prefix='%s/downloads?' % self._base_url,
+        url_prefix='{0!s}/downloads?'.format(self._base_url),
         params=[('wrkey', 'BOGUS_WRAPPED_KEY'),
                 ('apikey', 'BOGUS_API_KEY')],
-        request='s;%d\nlista;mac\nlistb;mac\n' % (1<<10),
-        response='m:%s\n%s' % (self._Mac(response), response))
+        request='s;{0:d}\nlista;mac\nlistb;mac\n'.format((1<<10)),
+        response='m:{0!s}\n{1!s}'.format(self._Mac(response), response))
 
     # Perform the actual download request.
     sblists = [sblist.List('lista'), sblist.List('listb')]
@@ -234,16 +234,16 @@ class ServerTest(unittest.TestCase):
                      list(response.listops['listb'][1]._chunknums))
 
   def testGetFullHashes(self):
-    response = 'lista:123:32\n89AB%s' % (28 * 'A')
+    response = 'lista:123:32\n89AB{0!s}'.format((28 * 'A'))
     self._fake_sb_server.SetResponse(
-        url_prefix='%s/gethash?' % self._base_url,
+        url_prefix='{0!s}/gethash?'.format(self._base_url),
         params=[('wrkey', 'BOGUS_WRAPPED_KEY'),
                 ('apikey', 'BOGUS_API_KEY')],
         request='4:12\n0123456789AB',
-        response='%s\n%s' % (self._Mac(response), response))
+        response='{0!s}\n{1!s}'.format(self._Mac(response), response))
 
     self._fake_sb_server.SetResponse(
-        url_prefix='%s/gethash?' % self._base_url,
+        url_prefix='{0!s}/gethash?'.format(self._base_url),
         params=[('wrkey', 'BOGUS_WRAPPED_KEY'),
                 ('apikey', 'BOGUS_API_KEY')],
         request='10:10\n0123456789',
@@ -252,7 +252,7 @@ class ServerTest(unittest.TestCase):
     resp = self._server.GetFullHashes(['0123', '4567', '89AB'], 4)
     self.assertTrue(isinstance(resp, server.GetHashResponse))
     self.assertFalse(resp.rekey)
-    self.assertEqual({'lista': { 123: set(['89AB%s' % (28 * 'A')])}},
+    self.assertEqual({'lista': { 123: set(['89AB{0!s}'.format((28 * 'A'))])}},
                      resp.listmap)
 
     resp = self._server.GetFullHashes(['0123456789'], 10)

--- a/python/util.py
+++ b/python/util.py
@@ -23,8 +23,8 @@ import struct
 
 def Bin2Hex(hash):
   hexchars = []
-  for i in struct.unpack('%dB' % (len(hash),), hash):
-    hexchars.append('%02x' % (i,))
+  for i in struct.unpack('{0:d}B'.format(len(hash)), hash):
+    hexchars.append('{0:02x}'.format(i))
   return ''.join(hexchars)
 
 def GetHash256(expr):

--- a/testing/safebrowsing_test_server.py
+++ b/testing/safebrowsing_test_server.py
@@ -132,8 +132,7 @@ def VerifyTestComplete():
   complete = True
   for (step, step_list) in response_data_by_step.iteritems():
     if len(step_list):
-      print ("Step %s has %d request(s) that were not made %s" %
-             (step, len(step_list), step_list))
+      print ("Step {0!s} has {1:d} request(s) that were not made {2!s}".format(step, len(step_list), step_list))
       complete = False
 
   for (step, hash_step_dict) in hash_data_by_step.iteritems():
@@ -149,13 +148,13 @@ def VerifyTestComplete():
                 expression))
         # This information is slightly redundant with what will be printed below
         # but it is occasionally worth seeing.
-        print "Response %s" % response
+        print "Response {0!s}".format(response)
         cur_index = 0
         while cur_index < len(response):
           end_header_index = response.find('\n', cur_index + 1)
           header = response[cur_index:end_header_index]
           (listname, chunk_num, hashdatalen) = header.split(":")
-          print "   List '%s' in add chunk num %s" % (listname, chunk_num)
+          print "   List '{0!s}' in add chunk num {1!s}".format(listname, chunk_num)
           cur_index = end_header_index + int(hashdatalen) + 1
 
         complete = False
@@ -187,7 +186,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if client_key is None:
       return response
     unescaped_mac = hmac.new(client_key, response, sha).digest()
-    return "%s%s\n%s" % (is_downloads_request and "m:" or "",
+    return "{0!s}{1!s}\n{2!s}".format(is_downloads_request and "m:" or "",
                        base64.urlsafe_b64encode(unescaped_mac),
                        response)
 
@@ -235,7 +234,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if not hashes_for_step:
       self.send_response(400)
       self.end_headers()
-      print "No response for step %d" % step
+      print "No response for step {0:d}".format(step)
       return
 
     post_data = self.rfile.read(int(self.headers['Content-Length']))
@@ -246,7 +245,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if not match:
       self.send_response(400)
       self.end_headers()
-      print "Gethash request is malformed %s" % post_data
+      print "Gethash request is malformed {0!s}".format(post_data)
       return
 
     prefixsize = int(match.group('prefixsize'))
@@ -286,7 +285,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if not responses_for_step:
       self.send_response(400)
       self.end_headers()
-      print "No responses for step %d" % step
+      print "No responses for step {0:d}".format(step)
       return
 
     # Delete unnecessary params
@@ -308,9 +307,9 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if expected_path != path or param_key != expected_params:
       self.send_response(400)
       self.end_headers()
-      print "Expected request with path %s and params %s." % (expected_path,
+      print "Expected request with path {0!s} and params {1!s}.".format(expected_path,
                                                               expected_params)
-      print "Actual request path %s and params %s" % (path, param_key)
+      print "Actual request path {0!s} and params {1!s}".format(path, param_key)
       return
 
     # Remove request that was just made
@@ -327,7 +326,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     if path == DOWNLOADS_PATH:
       # Need to have the redirects point to the current port.
       server_response = re.sub(r'localhost:\d+',
-                               '%s:%d' % (self.server.server_address[0],
+                               '{0!s}:{1:d}'.format(self.server.server_address[0],
                                           self.server.server_port),
                                server_response)
       # Remove the current MAC, because it's going to be wrong now.


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:google-safe-browsing?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:google-safe-browsing?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
